### PR TITLE
Compatibility with PocketMine 4.6.0 for Minecraft 1.19.10 (Protocol 534)

### DIFF
--- a/plugin.yml
+++ b/plugin.yml
@@ -1,6 +1,6 @@
 ---
 name: HideCommands
-version: 2.0.2
+version: 2.0.3
 main: Himbeer\HideCommands\Main
 api: 4.0.0
 mcpe-protocol:
@@ -8,6 +8,7 @@ mcpe-protocol:
   - 486 # v1.18.10
   - 503 # v1.18.30
   - 527 # v1.19.0
+  - 534 # v1.19.10
 author: Himbeer
 website: himbeer.me
 description: Remove specific commands from the in-game command suggestions.


### PR DESCRIPTION
Compatibility with PocketMine 4.6.0 for Minecraft 1.19.10 (Protocol 534)

And Bump Version to 2.0.3